### PR TITLE
Use `defaultMiddleware` for `runDefault` or custom middleware for `run`

### DIFF
--- a/src/Concur/Replica/Run.hs
+++ b/src/Concur/Replica/Run.hs
@@ -22,6 +22,7 @@ import           Replica.VDOM                    (fireEvent, defaultIndex)
 import           Replica.VDOM.Types              (DOMEvent(DOMEvent), HTML)
 
 import           Network.WebSockets.Connection   (ConnectionOptions, defaultConnectionOptions)
+import           Network.Wai                     (Middleware)
 import qualified Network.Wai.Handler.Replica     as R
 import qualified Network.Wai.Handler.Warp        as W
 
@@ -35,12 +36,12 @@ stepWidget v = case v of
   Free (StepBlock io next) -> io >>= stepWidget . next
   Free Forever             -> pure Nothing
 
-run :: Int -> HTML -> ConnectionOptions -> Widget HTML a -> IO ()
-run port index connectionOptions widget
+run :: Int -> HTML -> ConnectionOptions -> Middleware -> Widget HTML a -> IO ()
+run port index connectionOptions middleware widget
   = W.run port
-  $ R.app index connectionOptions (step widget) stepWidget
+  $ R.app index connectionOptions middleware (step widget) stepWidget
 
 runDefault :: Int -> T.Text -> Widget HTML a -> IO ()
 runDefault port title widget
   = W.run port
-  $ R.app (defaultIndex title []) defaultConnectionOptions (step widget) stepWidget
+  $ R.app (defaultIndex title []) defaultConnectionOptions R.defaultMiddleware (step widget) stepWidget

--- a/src/Concur/Replica/Run.hs
+++ b/src/Concur/Replica/Run.hs
@@ -44,4 +44,4 @@ run port index connectionOptions middleware widget
 runDefault :: Int -> T.Text -> Widget HTML a -> IO ()
 runDefault port title widget
   = W.run port
-  $ R.app (defaultIndex title []) defaultConnectionOptions R.emptyMiddleware (step widget) stepWidget
+  $ R.app (defaultIndex title []) defaultConnectionOptions id (step widget) stepWidget

--- a/src/Concur/Replica/Run.hs
+++ b/src/Concur/Replica/Run.hs
@@ -44,4 +44,4 @@ run port index connectionOptions middleware widget
 runDefault :: Int -> T.Text -> Widget HTML a -> IO ()
 runDefault port title widget
   = W.run port
-  $ R.app (defaultIndex title []) defaultConnectionOptions R.defaultMiddleware (step widget) stepWidget
+  $ R.app (defaultIndex title []) defaultConnectionOptions R.emptyMiddleware (step widget) stepWidget

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ extra-deps:
 # - ./vendor/replica
 # - ./vendor/concur-core
 - git: https://github.com/pkamenarsky/replica.git
-  commit: 69249ec760b8b8272d302269b54ddc4531d508a9
+  commit: 4d93f16fe7397ee13a8842a01dad9224870c025e
 - git: https://github.com/pkamenarsky/concur.git
   commit: 6c6bcc07b2688182945b28f154a013eee3f624c5
   subdirs:


### PR DESCRIPTION
`run` and `runDefault` updated to work with the new middleware support as discussed in https://github.com/pkamenarsky/replica/pull/10